### PR TITLE
Fix bug: flush job after first try

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,10 +113,12 @@ Yajob.prototype.take = function (count) {
 					const done = yield job.attrs;
 
 					if (done === false) {
+						const status = job.attempts < maxTrys ? Yajob.status.new : Yajob.status.failed;
+
 						/* eslint-disable no-loop-func */
 						collection.then(c => c.update(
 							{_id: job._id},
-							{status: job.attempts < maxTrys ? Yajob.status.new : Yajob.status.failed}
+							{$set: {status}}
 						));
 					} else {
 						ids.push(job._id);


### PR DESCRIPTION
After first try job

``` js
{ _id: 56b864582e2aaa113d9fd2eb,
  status: 1,
  attempts: 1,
  attrs: { test: 'wow' },
  scheduledAt: Mon Feb 08 2016 14:48:08 GMT+0500 (YEKT),
  priority: 0,
  takenBy: 56b864582e2aaa113d9fd2ed,
  takenAt: Mon Feb 08 2016 14:48:10 GMT+0500 (YEKT) }
```

transform to:

``` js
{ _id: 56b864582e2aaa113d9fd2eb, status: 0 }
```

because `update` replace job to `{status: 0 }`.

This PR fix bug, update only `status`.
