### PR TITLE
History Limit

### DIFF
--- a/test/take.js
+++ b/test/take.js
@@ -2,6 +2,10 @@ import test from 'ava';
 import yajob from '..';
 import {QueueDb} from './_utils';
 
+async function wait(time) {
+	return new Promise(resolve => setTimeout(resolve, time));
+}
+
 test('take one', async t => {
 	const queueDb = await new QueueDb();
 	const queue = yajob(queueDb.uri);
@@ -62,6 +66,64 @@ test('take limit', async t => {
 
 		const taken = Array.from(await queue.take(2));
 		t.same(taken[0], {test: 'wow'});
+	} finally {
+		await queueDb.close();
+	}
+});
+
+test('take with `historyInterval` should not delete job after itself', async t => {
+	const queueDb = await new QueueDb();
+	const queue = yajob(queueDb.uri);
+
+	try {
+		await queue.put({test: 'wow'});
+
+		const job = await queue.historyInterval(100).take();
+		job.next();
+		job.next();
+
+		await wait(1000);
+
+		const jobs = await queueDb.db.collection('default').find().toArray();
+		t.same(jobs.length, 1);
+	} finally {
+		await queueDb.close();
+	}
+});
+
+test('take with zero `historyInterval` should clean all `taken` jobs', async t => {
+	const queueDb = await new QueueDb();
+	const queue = yajob(queueDb.uri);
+
+	try {
+		await queue.put({test: 'wow'});
+
+		const job = await queue.historyInterval(0).take();
+		job.next();
+		job.next();
+
+		await wait(1000);
+
+		const jobs = await queueDb.db.collection('default').find().toArray();
+		t.same(jobs.length, 0);
+	} finally {
+		await queueDb.close();
+	}
+});
+
+test('take should clean only old `taken` jobs', async t => {
+	const queueDb = await new QueueDb();
+	const queue = yajob(queueDb.uri);
+
+	try {
+		await queue.put({test: 'wow1'});
+		await queue.take();
+		await queue.put({test: 'wow2'});
+		await wait(200);
+		await queue.historyInterval(100).take();
+
+		const jobs = await queueDb.db.collection('default').find().toArray();
+		t.same(jobs.length, 1);
 	} finally {
 		await queueDb.close();
 	}


### PR DESCRIPTION
Sometimes it is necessary not to delete jobs with `taken` status from mongo right after running `.next()` on jobs batch. For example for logs.
I want to add `.historyInterval(100)` method to use it like this:`queue.historyInterval(100).take()`.
- It won't delete job from queue after execution.
- On each `queue.historyInterval(100).take()` call it will delete jobs with `taken` status older than `new Date(new Date() - historyInterval)`

For backward compatibility `.take()` delete jobs like before. `.historyInterval(0).take()` do the same
